### PR TITLE
Enable bootslide tile sections

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -88,30 +88,59 @@
             label: 'Tile Menu',
             layout: 'tiles',
             width: 360,
-            target: [
-              {
-                label: 'Fruits',
-                target: [ {label: 'Apple', args: ['Honeycrisp'], target: apple}, {label: 'Banana'}, {label: 'Kiwi', args: [true]} ]
-              },
-              {
-                label: 'Submenu',
-                target: [
-                  { label: 'Hey', target: () => alert(('Hey!'))}
-                ]
-              },
-              {
-                label: 'Alert',
-                target: () => alert('Alert!')
-              },
-              {
-                label: 'Champs',
-                target: () => alert('E-A-G-L-E-S EAGLES!')
-              },
-              {
-                label: 'This far...',
-                target: () => alert('No further!')
-              }
-            ]
+            sections: [{
+              label: 'First Section',
+              target: [
+                {
+                  label: 'Fruits',
+                  target: [ {label: 'Apple', args: ['Honeycrisp'], target: apple}, {label: 'Banana'}, {label: 'Kiwi', args: [true]} ]
+                },
+                {
+                  label: 'Submenu',
+                  target: [
+                    { label: 'Hey', target: () => alert(('Hey!'))}
+                  ]
+                },
+                {
+                  label: 'Alert',
+                  target: () => alert('Alert!')
+                },
+                {
+                  label: 'Champs',
+                  target: () => alert('E-A-G-L-E-S EAGLES!')
+                },
+                {
+                  label: 'This far...',
+                  target: () => alert('No further!')
+                }
+              ]
+            },{
+              label: 'Second Section',
+              target: [
+                {
+                  label: 'Fruits',
+                  target: [ {label: 'Apple', args: ['Honeycrisp'], target: apple}, {label: 'Banana'}, {label: 'Kiwi', args: [true]} ]
+                },
+                {
+                  label: 'Submenu',
+                  target: [
+                    { label: 'Hey', target: () => alert(('Hey!'))}
+                  ]
+                },
+                {
+                  label: 'Alert',
+                  target: () => alert('Alert!')
+                },
+                {
+                  label: 'Champs',
+                  target: () => alert('E-A-G-L-E-S EAGLES!')
+                },
+                {
+                  label: 'This far...',
+                  target: () => alert('No further!')
+                }
+              ]
+            }]
           }
 
           var tileBootslide = window.tileBootslide = new Bootslide(tileMenu, {

--- a/example/index.html
+++ b/example/index.html
@@ -84,66 +84,36 @@
 
           $('#container').html(bootslide.render())
 
-          var tileMenu = {
+          let sampleTargets = [{
+              label: 'Fruits',
+              target: [ {label: 'Apple', args: ['Honeycrisp'], target: apple}, {label: 'Banana'}, {label: 'Kiwi', args: [true]} ]
+            },
+            {
+              label: 'Submenu',
+              target: [
+                { label: 'Hey', target: () => alert(('Hey!'))}
+              ]
+            },
+            {
+              label: 'Alert',
+              target: () => alert('Alert!')
+            },
+            {
+              label: 'Champs',
+              target: () => alert('E-A-G-L-E-S EAGLES!')
+            },
+            {
+              label: 'This far...',
+              target: () => alert('No further!')
+            }
+          ]
+
+          window.tileBootslide = new Bootslide({
             label: 'Tile Menu',
             layout: 'tiles',
             width: 360,
-            sections: [{
-              label: 'First Section',
-              target: [
-                {
-                  label: 'Fruits',
-                  target: [ {label: 'Apple', args: ['Honeycrisp'], target: apple}, {label: 'Banana'}, {label: 'Kiwi', args: [true]} ]
-                },
-                {
-                  label: 'Submenu',
-                  target: [
-                    { label: 'Hey', target: () => alert(('Hey!'))}
-                  ]
-                },
-                {
-                  label: 'Alert',
-                  target: () => alert('Alert!')
-                },
-                {
-                  label: 'Champs',
-                  target: () => alert('E-A-G-L-E-S EAGLES!')
-                },
-                {
-                  label: 'This far...',
-                  target: () => alert('No further!')
-                }
-              ]
-            },{
-              label: 'Second Section',
-              target: [
-                {
-                  label: 'Fruits',
-                  target: [ {label: 'Apple', args: ['Honeycrisp'], target: apple}, {label: 'Banana'}, {label: 'Kiwi', args: [true]} ]
-                },
-                {
-                  label: 'Submenu',
-                  target: [
-                    { label: 'Hey', target: () => alert(('Hey!'))}
-                  ]
-                },
-                {
-                  label: 'Alert',
-                  target: () => alert('Alert!')
-                },
-                {
-                  label: 'Champs',
-                  target: () => alert('E-A-G-L-E-S EAGLES!')
-                },
-                {
-                  label: 'This far...',
-                  target: () => alert('No further!')
-                }
-              ]
-            }]
-          }
-
-          var tileBootslide = window.tileBootslide = new Bootslide(tileMenu, {
+            target: sampleTargets
+          }, {
             el: $('#tile-menu'),
             defaultTarget: function () {
               console.log('default target', arguments)
@@ -151,6 +121,23 @@
           })
 
           tileBootslide.render()
+
+          window.tileBootslideSections = new Bootslide({
+            label: 'Tile Menu W/ Sections',
+            layout: 'tiles',
+            width: 360,
+            sections: [{
+              label: 'First Section',
+              target: sampleTargets
+            },{
+              label: 'Second Section',
+              target: sampleTargets
+            }]
+          }, {
+            el: $('#tile-menu-with-sections')
+          })
+
+          tileBootslideSections.render()
         }
     </script>
     <style>
@@ -160,7 +147,7 @@
         background-color: #eed;
       }
 
-      #tile-menu {
+      #tile-menu, #tile-menu-with-sections {
         margin-top: 20px;
       }
 
@@ -197,6 +184,8 @@
     <div id="container"></div>
 
     <div id="tile-menu"></div>
+
+    <div id="tile-menu-with-sections"></div>
 
   </body>
 </html>

--- a/src/bootslide.js
+++ b/src/bootslide.js
@@ -215,7 +215,11 @@ Bootslide.prototype.buildSections = function (menu, sections, backTo) {
 
   var container = $('<div>').addClass('bootslide-container-row')
 
-  var createList = (targets) => {
+  /**
+   * Takes an array of targets and creates clickable bootslide endpoints.
+   * @param {Array} targets the targets to be rendered into a clickable list
+   */
+  var createList = targets => {
     var ul = $('<ul>')
       .addClass('bootslide-menu nav nav-list')
       .toggleClass('bootslide-tiles', menu.layout === 'tiles')
@@ -271,10 +275,10 @@ Bootslide.prototype.buildSections = function (menu, sections, backTo) {
         addAndContinue()
       }
     })
-
   }
 
-  // If there are sections to the menu,
+  // If there are sections to the menu, create those sections,
+  // placing menu items in each one
   if (menu.sections) {
     $.each(menu.sections, (i, section) => {
       let sectionLabel = $('<div class="bootslide-section-label">')
@@ -282,11 +286,10 @@ Bootslide.prototype.buildSections = function (menu, sections, backTo) {
       container.append(sectionLabel)
       createList(section.target)
     })
+  // else, just create the list of menu items
   } else {
     createList(menu.target)
   }
-
-
 
   sections.unshift(section.append(container).get(0))
 

--- a/src/bootslide.js
+++ b/src/bootslide.js
@@ -40,7 +40,7 @@ util.inherits(Bootslide, EventEmitter)
 
 Bootslide.prototype.render = function () {
   this.el.addClass('bootslide-container').width(this.width)
-  
+
   var slider = $('<div>').addClass('bootslide-menu-slider')
     , self = this
 
@@ -213,69 +213,89 @@ Bootslide.prototype.buildSections = function (menu, sections, backTo) {
     return section
   }
 
-  var ul = $('<ul>')
-    .addClass('bootslide-menu nav nav-list')
-    .toggleClass('bootslide-tiles', menu.layout === 'tiles')
+  var container = $('<div>').addClass('bootslide-container-row')
 
-  var self = this
+  var createList = (targets) => {
+    var ul = $('<ul>')
+      .addClass('bootslide-menu nav nav-list')
+      .toggleClass('bootslide-tiles', menu.layout === 'tiles')
 
-  $.each(menu.target, function (index, target) {
-    var label = getLabel(target.label)
-      , content = target.content ? target.content() : target.label
-      , a = $('<div data-target-id="#' + ('bootstrap-' + getId(target)) + '" class="bootslide-menu-item">')
-                .append(content)
-                .addClass(label.toLowerCase())
-      , li = $('<li>').append(a)
-                .css('display', target.hidden ? 'none' : '')
+    var self = this
 
-    ul.append(li)
+    $.each(targets, function (index, target) {
+      var label = getLabel(target.label)
+        , content = target.content ? target.content() : target.label
+        , a = $('<div data-target-id="#' + ('bootstrap-' + getId(target)) + '" class="bootslide-menu-item">')
+                  .append(content)
+                  .addClass(label.toLowerCase())
+        , li = $('<li>').append(a)
+                  .css('display', target.hidden ? 'none' : '')
 
-    function addAndContinue () {
-      li.addClass('bootslide-step')
-      // Keep digging
-      a.addClass('bootslide-scrollable')
-      a.prepend(self.nextIcon)
-      return self.buildSections(target, sections, section)
-    }
+      ul.append(li)
+      container.append(ul)
 
-    if (target.contentEndpoint) {
-      var newSection = addAndContinue()
-
-      a.click(function (e) {
-        prepareContentEndpoint(newSection)
-      })
-    } else if (typeof target.target === 'function' || (typeof target.target === 'undefined' && self.defaultTarget)) {
-      var fn = (typeof target.target === 'undefined' && self.defaultTarget) || target.target
-        , args = target.args || []
-
-      // If it's a function, that means it's the last step
-      li.addClass('bootslide-endpoint')
-      a.click(function (e) {
-        var _args = args.concat()
-        _args.unshift(e)
-        fn.apply(this, _args)
-      })
-      // If they set up a last icon for each item
-      if (self.last) {
-        a.prepend(self.last)
+      function addAndContinue () {
+        li.addClass('bootslide-step')
+        // Keep digging
+        a.addClass('bootslide-scrollable')
+        a.prepend(self.nextIcon)
+        return self.buildSections(target, sections, section)
       }
-    } else if (typeof target.target === 'string' ) {
-      li.addClass('bootslide-endpoint')
-      // If it's a string, treat it as a basic url
-      a.attr('data-target-id', target.target)
-    } else {
-      addAndContinue()
-    }
-  })
 
-  sections.unshift(section.append(ul).get(0))
+      if (target.contentEndpoint) {
+        var newSection = addAndContinue()
+
+        a.click(function (e) {
+          prepareContentEndpoint(newSection)
+        })
+      } else if (typeof target.target === 'function' || (typeof target.target === 'undefined' && self.defaultTarget)) {
+        var fn = (typeof target.target === 'undefined' && self.defaultTarget) || target.target
+          , args = target.args || []
+
+        // If it's a function, that means it's the last step
+        li.addClass('bootslide-endpoint')
+        a.click(function (e) {
+          var _args = args.concat()
+          _args.unshift(e)
+          fn.apply(this, _args)
+        })
+        // If they set up a last icon for each item
+        if (self.last) {
+          a.prepend(self.last)
+        }
+      } else if (typeof target.target === 'string' ) {
+        li.addClass('bootslide-endpoint')
+        // If it's a string, treat it as a basic url
+        a.attr('data-target-id', target.target)
+      } else {
+        addAndContinue()
+      }
+    })
+
+  }
+
+  // If there are sections to the menu,
+  if (menu.sections) {
+    $.each(menu.sections, (i, section) => {
+      let sectionLabel = $('<div class="bootslide-section-label">')
+        .append(section.label)
+      container.append(sectionLabel)
+      createList(section.target)
+    })
+  } else {
+    createList(menu.target)
+  }
+
+
+
+  sections.unshift(section.append(container).get(0))
 
   return section
 }
 
 Bootslide.prototype.back = function () {
   var previous = $('.bootslide-section.bootslide-current', this.el).prev()
-  
+
   if (previous.length > 0) {
     this.slide(previous, true)
   }
@@ -289,7 +309,7 @@ Bootslide.prototype.toggleItem = function (id, show) {
   let item = $(this.el).find(`[data-target-id="#bootstrap-${id}"]`)
   if (item.parent().length === 0) {
     return
-  } 
+  }
 
   item.parent().css('display', show ? '' : 'none')
 


### PR DESCRIPTION
We need the ability to create labeled sections inside the tiled bootslide menus for https://github.com/SpiderStrategies/Scoreboard/issues/27069
This enables us to pass sections in to accomplish that